### PR TITLE
feat(intune): chrome extension installation using scripts and ps1

### DIFF
--- a/scripts/chrome/intune/windows/v1/zluri-windows-chrome-forceinstall-intune.ps1
+++ b/scripts/chrome/intune/windows/v1/zluri-windows-chrome-forceinstall-intune.ps1
@@ -1,0 +1,42 @@
+$extensionID = 'cmobkdiplndgpjodaioofofmcikimbdb;https://clients2.google.com/service/update2/crx'
+$path = 'HKLM:\Software\Policies\Google\Chrome\ExtensionInstallForcelist'
+
+# Ensure the registry key exists
+if (!(Test-Path $path)) {
+    New-Item -Path $path -Force
+}
+
+# Function to add extensions incrementally
+function Add-Extension {
+    param (
+        [string]$extensionId,
+        [string]$path
+    )
+
+    # Check if the extension ID already exists in the registry
+    $existingKeys = Get-ItemProperty -Path $path
+    $existingExtension = $existingKeys.PSObject.Properties | Where-Object { $_.Value -eq $extensionId }
+
+    # If the extension already exists, skip adding it
+    if ($existingExtension) {
+        Write-Host "Extension with ID $extensionId already exists. Skipping addition."
+        return
+    }
+    
+    # Find the highest current index in the registry
+    $maxIndex = 0
+    $existingKeys = Get-ItemProperty -Path $path
+    foreach ($key in $existingKeys.PSObject.Properties) {
+        if ($key.Name -match '^\d+$' -and [int]$key.Name -gt $maxIndex) {
+            $maxIndex = [int]$key.Name
+        }
+    }
+
+    # Increment index for the new extension
+    $newIndex = $maxIndex + 1
+    Set-ItemProperty -Path $path -Name $newIndex -Value $extensionId -Type String -Force
+    Write-Host "Added extension at index $newIndex"
+}
+
+# Add the first extension
+Add-Extension -extensionId $extensionID -path $path

--- a/scripts/chrome/intune/windows/v1/zluri-windows-chrome-policy-intune.ps1
+++ b/scripts/chrome/intune/windows/v1/zluri-windows-chrome-policy-intune.ps1
@@ -1,0 +1,11 @@
+$registry_path_chrome = "HKLM:\Software\Policies\Google\Chrome\3rdparty\extensions\cmobkdiplndgpjodaioofofmcikimbdb"
+$registry_path_chrome_policy="HKLM:\Software\Policies\Google\Chrome\3rdparty\extensions\cmobkdiplndgpjodaioofofmcikimbdb\policy"
+if (!(Test-Path $registry_path_chrome)) {
+ New-Item -Path $registry_path_chrome -Force -ItemType Directory |Out-Null
+}
+if (!(Test-Path $registry_path_chrome_policy)) {
+ New-Item -Path ("$registry_path_chrome_policy") -Force -ItemType Directory |Out-Null
+}
+Set-ItemProperty -Path $registry_path_chrome_policy -Name "OrgToken" -Value "<ORGTOKEN>" -Force
+Set-ItemProperty -Path $registry_path_chrome_policy -Name "AgentOpenLoginTab" -Value "true" -Force
+Set-ItemProperty -Path $registry_path_chrome_policy -Name "DisableLogout" -Value "true" -Force


### PR DESCRIPTION
This pull request includes important changes to two PowerShell scripts used for configuring Chrome policies via Intune on Windows. The updates primarily focus on the addition and management of Chrome extensions and their policies.

### Chrome Extension Management:

* [`scripts/chrome/intune/windows/v1/zluri-windows-chrome-forceinstall-intune.ps1`](diffhunk://#diff-81e9f3ddfaaf133816eca40731ff24cea2d97b558518e17bf476ec8d3684ae14R1-R42): Added a script to force install a Chrome extension by ensuring the registry key exists, and incrementally adding the extension if it is not already present.

### Chrome Policy Configuration:

* [`scripts/chrome/intune/windows/v1/zluri-windows-chrome-policy-intune.ps1`](diffhunk://#diff-48f8122cfc069f5a54b16c351ed707147ef1cee51139452efaac04ef86c5e6dbR1-R11): Added a script to configure Chrome policies for a specific extension by creating necessary registry paths and setting policy properties such as `OrgToken`, `AgentOpenLoginTab`, and `DisableLogout`.