### PR TITLE
feat(agents): added restart script for zluri hide icon

### DIFF
--- a/scripts/mac/generic/zluri-generic-mac-hide-icon-script.sh
+++ b/scripts/mac/generic/zluri-generic-mac-hide-icon-script.sh
@@ -17,11 +17,6 @@ if [ -z "$CURRENT_USER" ]; then
     exit 1
 fi
 
-if [ "$ORG_TOKEN" = "<orgToken>" ]; then
-    echo "Error: ORG_TOKEN must be set"
-    exit 1
-fi
-
 # Create config JSON
 CONFIG_JSON=$(cat << EOF 
 {

--- a/scripts/mac/generic/zluri-generic-mac-hide-icon-script.sh
+++ b/scripts/mac/generic/zluri-generic-mac-hide-icon-script.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Get current user and home directory
+CURRENT_USER=$(echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ && ! /loginwindow/ { print $3 }')
+HOMEDIR=$(/usr/bin/dscl . -read /Users/"$CURRENT_USER" NFSHomeDirectory | /usr/bin/cut -d' ' -f2)
+
+# Configuration variables
+ORG_TOKEN=<orgToken> # needs to be added by the customer
+INTERVAL=600000 # check enrollment API in ms
+SCREEN_RECORD=off # screen recording permission
+LOCAL_SERVER=on # node auth server, cross auth of DA & BA, as per the customer pref
+HIDE_ZLURI_TRAY_ICON=true # Setting this flag will not show the zluri icon on the status bar above
+
+# Validate required inputs
+if [ -z "$CURRENT_USER" ]; then
+    echo "Error: Could not determine current user"
+    exit 1
+fi
+
+if [ "$ORG_TOKEN" = "<orgToken>" ]; then
+    echo "Error: ORG_TOKEN must be set"
+    exit 1
+fi
+
+# Create config JSON
+CONFIG_JSON=$(cat << EOF 
+{
+  "org_token": "$ORG_TOKEN",
+  "interval": "$INTERVAL",
+  "screen_recording": "$SCREEN_RECORD",
+  "silent_auth": "on",
+  "local_server": "$LOCAL_SERVER",
+  "hide_zluri_tray_icon": $HIDE_ZLURI_TRAY_ICON
+}
+EOF
+)
+
+echo "Current user: $CURRENT_USER"
+echo "Home directory: $HOMEDIR"
+echo "Local server: $LOCAL_SERVER"
+
+# Create temp directory if it doesn't exist
+if [ ! -d /tmp/zluritemp ]; then
+   mkdir -p /tmp/zluritemp
+fi
+
+# Write config file to temp directory
+echo "$CONFIG_JSON" > /tmp/zluritemp/client-config.json
+echo "Written config to temp directory"
+
+# Create application support directory and write config
+mkdir -p "$HOMEDIR/Library/Application Support/zluri"
+echo "$CONFIG_JSON" > "$HOMEDIR/Library/Application Support/zluri/client-config.json"
+echo "Written config to application directory"
+
+# Kill existing zluri process
+if pgrep -x zluri > /dev/null; then
+    echo "Stopping zluri process"
+    pkill -x zluri
+    sleep 5
+fi
+
+# Start zluri application
+echo "Starting zluri application"
+open /Applications/zluri.app
+
+echo "Configuration completed"
+exit 0

--- a/scripts/windows/generic/zluri-generic-windows-hide-icon-script.ps1
+++ b/scripts/windows/generic/zluri-generic-windows-hide-icon-script.ps1
@@ -146,7 +146,7 @@ try {
     Start-Process -FilePath "cmd.exe" -ArgumentList $cmdArgs -WindowStyle Hidden -ErrorAction Stop
     
     # Waiting for a moment to start
-    Start-Sleep -Seconds 2
+    Start-Sleep -Seconds 5
     
     # Verifing it started
     if (Get-Process -Name "zluri" -ErrorAction SilentlyContinue) {

--- a/scripts/windows/generic/zluri-generic-windows-hide-icon-script.ps1
+++ b/scripts/windows/generic/zluri-generic-windows-hide-icon-script.ps1
@@ -127,9 +127,10 @@ if ($ZluriProcess) {
     Write-Host "Stopping zluri process"
     Stop-Process -Name "zluri" -Force -ErrorAction SilentlyContinue
 
-    # Wait up to 10 seconds
-    if (Wait-Process -Name "zluri" -Timeout 60 -ErrorAction SilentlyContinue) {
-        Write-Output "zluri stopped gracefully"
+    # Wait up to 60 seconds
+    Wait-Process -Name "zluri" -Timeout 60 -ErrorAction SilentlyContinue  
+    if (-not (Get-Process -Name "zluri" -ErrorAction SilentlyContinue)) {  
+        Write-Output "zluri stopped gracefully"  
     }
 }
 
@@ -144,8 +145,8 @@ try {
     $cmdArgs = "/c start `"`" `"$ZluriExe`""
     Start-Process -FilePath "cmd.exe" -ArgumentList $cmdArgs -WindowStyle Hidden -ErrorAction Stop
     
-    # Wait up to 10 seconds for zluri to start
-    for ($i = 0; $i -lt 10; $i++) {
+    # Wait up to 120 seconds for zluri to start
+    for ($i = 0; $i -lt 120; $i++) {
         $proc = Get-Process -Name "zluri" -ErrorAction SilentlyContinue
         if ($proc) {
             Write-Output "zluri started"

--- a/scripts/windows/generic/zluri-generic-windows-hide-icon-script.ps1
+++ b/scripts/windows/generic/zluri-generic-windows-hide-icon-script.ps1
@@ -1,0 +1,101 @@
+# Windows MDM Configuration Script
+
+# Configuration variables
+$ORG_TOKEN = "<orgToken>" # needs to be added by the customer
+$INTERVAL = 600000  # check enrollment API in ms
+$SCREEN_RECORD = "off"  # screen recording permission
+$LOCAL_SERVER = "on"  # node auth server, cross auth of DA & BA, as per the customer pref
+$HIDE_ZLURI_TRAY_ICON = $true  # Setting this flag will not show the zluri icon on the status bar
+
+# Validate required inputs
+if ($ORG_TOKEN -eq "<orgToken>" -or [string]::IsNullOrEmpty($ORG_TOKEN)) {
+    Write-Host "Error: ORG_TOKEN must be set in the script"
+    exit 1
+}
+
+# Function to find Zluri installation
+function Find-ZluriEntries {
+    $uninstallPaths = @(
+        "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+        "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
+        "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"
+    )
+    $entries = @()
+    foreach ($path in $uninstallPaths) {
+        if (Test-Path $path) {
+            Get-ChildItem $path | ForEach-Object {
+                $props = Get-ItemProperty -Path $_.PSPath -ErrorAction SilentlyContinue
+                if ($props.DisplayName -match 'zluri') {
+                    $entries += [PSCustomObject]@{
+                        DisplayName     = $props.DisplayName
+                        Version         = $props.DisplayVersion
+                        UninstallString = $props.UninstallString
+                        KeyPath         = $_.PSPath
+                    }
+                }
+            }
+        }
+    }
+    return $entries
+}
+
+# Check if Zluri is installed
+$ZluriEntries = Find-ZluriEntries
+if ($ZluriEntries.Count -eq 0) {
+    Write-Host "Error: Zluri is not installed"
+    exit 1
+}
+
+Write-Host "Current user: $env:USERNAME"
+Write-Host "Zluri found: $($ZluriEntries[0].DisplayName) - Version: $($ZluriEntries[0].Version)"
+Write-Host "Local server: $LOCAL_SERVER"
+
+# Create config JSON
+$ConfigJson = @{
+    "org_token" = $ORG_TOKEN
+    "interval" = $INTERVAL
+    "screen_recording" = $SCREEN_RECORD
+    "silent_auth" = "on"
+    "local_server" = $LOCAL_SERVER
+    "hide_zluri_tray_icon" = $HIDE_ZLURI_TRAY_ICON
+} | ConvertTo-Json -Depth 10
+
+# Create temp directory if it doesn't exist
+$TempDir = "C:\temp\zluritemp"
+if (-not (Test-Path $TempDir)) {
+    New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
+}
+
+# Write config file to temp directory
+$ConfigJson | Out-File -FilePath "$TempDir\client-config.json" -Encoding UTF8
+Write-Host "Written config to temp directory"
+
+# Create ProgramData directory and write config
+$ProgramDataDir = "C:\ProgramData\zluri"
+if (-not (Test-Path $ProgramDataDir)) {
+    New-Item -ItemType Directory -Path $ProgramDataDir -Force | Out-Null
+}
+
+$ConfigJson | Out-File -FilePath "$ProgramDataDir\client-config.json" -Encoding UTF8
+Write-Host "Written config to ProgramData directory"
+
+# Kill existing zluri process
+$ZluriProcess = Get-Process -Name "zluri" -ErrorAction SilentlyContinue
+if ($ZluriProcess) {
+    Write-Host "Stopping zluri process"
+    Stop-Process -Name "zluri" -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 3
+}
+
+# Start zluri application
+Write-Host "Starting zluri application"
+try {
+    Start-Process -FilePath "zluri" -ErrorAction Stop
+    Write-Host "Zluri started successfully"
+} catch {
+    Write-Host "Error starting zluri: $_"
+    exit 1
+}
+
+Write-Host "Configuration completed"
+exit 0

--- a/scripts/windows/generic/zluri-generic-windows-hide-icon-script.ps1
+++ b/scripts/windows/generic/zluri-generic-windows-hide-icon-script.ps1
@@ -128,7 +128,7 @@ if ($ZluriProcess) {
     Stop-Process -Name "zluri" -Force -ErrorAction SilentlyContinue
 
     # Wait up to 10 seconds
-    if (Wait-Process -Name "zluri" -Timeout 10 -ErrorAction SilentlyContinue) {
+    if (Wait-Process -Name "zluri" -Timeout 60 -ErrorAction SilentlyContinue) {
         Write-Output "zluri stopped gracefully"
     }
 }

--- a/scripts/windows/generic/zluri-generic-windows-hide-icon-script.ps1
+++ b/scripts/windows/generic/zluri-generic-windows-hide-icon-script.ps1
@@ -4,7 +4,7 @@
 $ORG_TOKEN = "<orgToken>" # needs to be added by the customer
 $INTERVAL = 600000  # check enrollment API in ms
 $SCREEN_RECORD = "off"  # screen recording permission
-$LOCAL_SERVER = "on"  # node auth server, cross auth of DA & BA, as per the customer pref
+$LOCAL_SERVER = "on"  # node auth server
 $HIDE_ZLURI_TRAY_ICON = $true  # Setting this flag will not show the zluri icon on the status bar
 
 # Validate required inputs
@@ -94,14 +94,14 @@ Write-Host "Zluri executable: $ZluriExe"
 Write-Host "Local server: $LOCAL_SERVER"
 
 # Creating config JSON
-$ConfigJson = @{
-    "org_token" = $ORG_TOKEN
-    "interval" = $INTERVAL
-    "screen_recording" = $SCREEN_RECORD
-    "silent_auth" = "on"
-    "local_server" = $LOCAL_SERVER
-    "hide_zluri_tray_icon" = $HIDE_ZLURI_TRAY_ICON
-} | ConvertTo-Json -Depth 10
+$configValues = '{
+    "org_token": "' + $ORG_TOKEN + '",
+    "interval": "' + $INTERVAL + '",
+    "screen_recording": "' + $SCREEN_RECORD + '",
+    "silent_auth": "on",
+    "local_server": "' + $LOCAL_SERVER + '",
+    "hide_zluri_tray_icon": "' + $HIDE_ZLURI_TRAY_ICON.ToString().ToLower() + '"
+}'
 
 # Creating temp directory if it doesn't exist
 $TempDir = "C:\temp\zluritemp"
@@ -110,17 +110,21 @@ if (-not (Test-Path $TempDir)) {
 }
 
 # Writing config file to temp directory
-$ConfigJson | Out-File -FilePath "$TempDir\client-config.json" -Encoding UTF8 -NoNewline
+$filePath = "$TempDir\client-config.json"
+New-Item -Path $filePath -ItemType "file" -Force -Value $configValues | Out-Null
 Write-Host "Written config to temp directory"
 
-# Creating ProgramData directory and write config
+# Creating ProgramData directory if it doesn't exist
 $ProgramDataDir = "C:\ProgramData\zluri"
 if (-not (Test-Path $ProgramDataDir)) {
     New-Item -ItemType Directory -Path $ProgramDataDir -Force | Out-Null
 }
 
-$ConfigJson | Out-File -FilePath "$ProgramDataDir\client-config.json" -Encoding UTF8 -NoNewline
+# Writing config file to ProgramData directory
+$filePath = "$ProgramDataDir\client-config.json"
+New-Item -Path $filePath -ItemType "file" -Force -Value $configValues | Out-Null
 Write-Host "Written config to ProgramData directory"
+
 
 # Kill existing zluri process
 $ZluriProcess = Get-Process -Name "zluri" -ErrorAction SilentlyContinue

--- a/scripts/windows/generic/zluri-generic-windows-hide-icon-script.ps1
+++ b/scripts/windows/generic/zluri-generic-windows-hide-icon-script.ps1
@@ -103,14 +103,9 @@ $configValues = '{
     "hide_zluri_tray_icon": "' + $HIDE_ZLURI_TRAY_ICON.ToString().ToLower() + '"
 }'
 
-# Creating temp directory if it doesn't exist
-$TempDir = "C:\temp\zluritemp"
-if (-not (Test-Path $TempDir)) {
-    New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
-}
 
-# Writing config file to temp directory
-$filePath = "$TempDir\client-config.json"
+# Writing config file to Local App Data directory
+$filePath = "$env:localappdata\client-config.json"
 New-Item -Path $filePath -ItemType "file" -Force -Value $configValues | Out-Null
 Write-Host "Written config to temp directory"
 


### PR DESCRIPTION
Added Generic Scripts for adding hide icon as true and restarting zluri

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS and Windows helpers to configure the Zluri agent: set org token, update interval, screen recording, local server, and tray-icon visibility.
  * Persist JSON configuration to user and system locations, validate environment, stop any running agent, restart it, and report status.

* **Chores**
  * Cross-platform deployment helpers for simpler installation and initial setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->